### PR TITLE
Now using apt.postgresql.org for all Debians.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,13 +7,9 @@
   tags:
     - postgres
 
-- name: Include Ubuntu tasks
-  include: ubuntu.yml
-  when: not "{{ ansible_distribution }}" != "Ubuntu"
-
 - name: Include Debian tasks
   include: debian.yml
-  when: not "{{ ansible_distribution }}" != "Debian"
+  when: ansible_os_family == "Debian"
 
 - name: Ensure apt cache is up to date
   apt: update_cache=yes
@@ -50,7 +46,7 @@
   notify: restart postgresql
   tags:
     - postgres
-    
+
 - meta: flush_handlers
 
 - name: ensure postgresql server is running

--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -1,5 +1,0 @@
----
-- name: ubuntu | add repository
-  apt_repository: repo='ppa:pitti/postgresql'
-  sudo: true
-  when: pg_repo == 'postgresql.org'


### PR DESCRIPTION
Hello,

The pitti/postgresql PPA was deprecated and is no longer usable (https://launchpad.net/~pitti/+archive/ubuntu/postgresql). As such, we should now use apt.postgresql.org for all Debians, since they maintain packages for both Debian and Ubuntu.

Thank you!
