### PR TITLE
Fixing the inclusion order of the extensions tasks.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,6 +45,8 @@
   tags:
     - postgres
 
+- include: extensions_common.yml
+
 - meta: flush_handlers
 
 - name: ensure postgresql server is started
@@ -52,8 +54,6 @@
   sudo: true
   tags:
     - postgres
-
-- include: extensions_common.yml
 
 - include: postgis.yml
   when: pg_postgis


### PR DESCRIPTION
If you add extensions to your postgres config and run the roles as
it was, it will fail to bring up the daemon, because the task that
actually installs the extensions is ran only after the task that
starts the daemon. As such, brought up the exclusions.yml so that
it runs before the daemon start.
