### PR TITLE
Fix pg_proxy_env with Ansible 2

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
     - postgresql-client-{{ pg_version }}
     - python-psycopg2
   register: db_setup
-  environment: pg_proxy_env
+  environment: '{{ pg_proxy_env }}'
   sudo: true
   tags: postgres_packages
 


### PR DESCRIPTION
When running the current role with Ansible 2, I get several deprecation warnings.  However this error below causes it not work:

```
TASK [zzet.postgresql : Ensure packages are installed] *************************
[DEPRECATION WARNING]: Using bare variables for environment is deprecated. Update your playbooks so that the environment value uses the full variable
syntax ('{{foo}}'). This feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in
ansible.cfg.
fatal: [10.207.2.230]: FAILED! => {"failed": true, "msg": "ERROR! environment must be a dictionary, received pg_proxy_env (<class 'ansible.parsing.yaml.objects.AnsibleUnicode'>)"}
```

I've tested the fix in my deployments.  Not sure what your plans are for getting this role compatible with Ansible 2.