### PR TITLE
reverting since 9.5 changes corrupted the install

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,9 @@ _This role under active development_.
 
 #### Supported PostgreSQL versions:
   
-  - PostgreSQL 9.1 
+  - PostgreSQL 9.1 (experimental * )
   - PostgreSQL 9.2
-  - PostgreSQL 9.3 
-  - PostgreSQL 9.4
-  - PostgreSQL 9.5
+  - PostgreSQL 9.3 (experimental * )
 
 * - Please, give me feedback if you have some problems on github issue tracker
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # default vars file for pg
-pg_version: 9.5
+pg_version: 9.2
 pg_encoding: 'UTF-8'
 pg_locale: 'en_US.UTF-8'
 


### PR DESCRIPTION
@zzet I realized that the v9.5 expects different settings in the `master.conf` file. The result is that the postgres process fails to start, which is 👎. This PR reverses the changes back to something that works, which is 👍. 

